### PR TITLE
:sparkles: Lifecycle Hooks 🚀

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,61 @@
+# Created by https://www.toptal.com/developers/gitignore/api/go,visualstudiocode,git
+# Edit at https://www.toptal.com/developers/gitignore?templates=go,visualstudiocode,git
+
+### Git ###
+# Created by git for backups. To disable backups in Git:
+# $ git config --global mergetool.keepBackup false
+*.orig
+
+# Created by git when using merge tools for conflicts
+*.BACKUP.*
+*.BASE.*
+*.LOCAL.*
+*.REMOTE.*
+*_BACKUP_*.txt
+*_BASE_*.txt
+*_LOCAL_*.txt
+*_REMOTE_*.txt
+
+### Go ###
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# End of https://www.toptal.com/developers/gitignore/api/go,visualstudiocode,git

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # 🌩 Zeus - Simple Dependency Injection Container
 
 ![GitHub](https://img.shields.io/github/license/otoru/zeus)
+![GitHub go.mod Go version (subdirectory of monorepo)](https://img.shields.io/github/go-mod/go-version/otoru/zeus)
 [![codecov](https://codecov.io/gh/Otoru/zeus/graph/badge.svg?token=Yfkyp5NZsY)](https://codecov.io/gh/Otoru/zeus)
 
 Zeus is a sleek and efficient dependency injection container for Go. Easily register "factories" (functions that create instances of types) and let zeus resolve those dependencies at runtime.
@@ -20,6 +21,10 @@ Register your dependencies and let zeus handle the rest.
 ### ⚠️ Cyclic Dependency Detection
 
 Zeus detects and reports cycles in your dependencies to prevent runtime errors.
+
+### 🪝 Hooks
+
+Zeus supports lifecycle hooks, allowing you to execute functions at the start and end of your application. This is especially useful for setups and teardowns, like establishing a database connection or gracefully shutting down services.
 
 ## 🚀 Getting Started
 
@@ -54,6 +59,55 @@ err := c.Run(func(s string) error {
     fmt.Println(s) // Outputs: Number: 42
     return nil
 })
+```
+
+### Using Hooks
+
+Zeus allows you to register hooks that run at the start and end of your application. This is useful for setting up and tearing down resources.
+
+```go
+c := zeus.New()
+
+// Servoce is a dummy service that depends on Hooks.
+type Service struct{}
+
+c.Provide(func(h zeus.Hooks) *Service {
+    h.OnStart(func() error {
+        fmt.Println("Starting up...")
+        return nil
+    })
+
+    h.OnStop(func() error {
+        fmt.Println("Shutting down...")
+        return nil
+    })
+    return &Service{}
+})
+
+c.Run(func(s *Service) {
+    fmt.Println("Main function running with the service!")
+})
+
+// Outputs:
+// Starting up...
+// Main function running with the service!
+// Shutting down...
+
+```
+
+### Error Handling
+
+Zeus uses `ErrorSet` to aggregate multiple errors. This is especially useful when multiple errors occur during the lifecycle of your application, such as during dependency resolution or hook execution.
+
+An ErrorSet can be returned from the Run method. Here's how you can handle it:
+
+```go
+err := c.Run(func() { /* ... */ })
+if es, ok := err.(*zeus.ErrorSet); ok {
+    for _, e := range es.Errors() {
+        fmt.Println(e)
+    }
+}
 ```
 
 ## 🤝 Contributing

--- a/container_test.go
+++ b/container_test.go
@@ -1,73 +1,37 @@
 package zeus
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/otoru/zeus/errs"
 	"gotest.tools/v3/assert"
 )
 
 func TestContainer(t *testing.T) {
 	t.Parallel()
 
-	t.Run("Provide", func(t *testing.T) {
-		t.Run("Not a function", func(t *testing.T) {
-			c := New()
-			got := c.Provide("string")
-			expected := NotAFunctionError{}
-			assert.ErrorIs(t, got, expected)
-		})
-
-		t.Run("Invalid return count", func(t *testing.T) {
-			c := New()
-			got := c.Provide(func() (int, string, error) { return 0, "", nil })
-			expected := InvalidFactoryReturnError{NumReturns: 3}
-
-			assert.ErrorIs(t, got, expected)
-		})
-
-		t.Run("Second return value not is a error", func(t *testing.T) {
-			c := New()
-			got := c.Provide(func() (int, string) { return 0, "" })
-			expected := UnexpectedReturnTypeError{TypeName: "string"}
-
-			assert.ErrorIs(t, got, expected)
-		})
-
-		t.Run("Valid factory", func(t *testing.T) {
-			c := New()
-			err := c.Provide(func() int { return 0 })
-
-			assert.NilError(t, err)
-		})
-
-		t.Run("Duplicated factory", func(t *testing.T) {
-			c := New()
-			c.Provide(func() int { return 0 })
-			got := c.Provide(func() int { return 1 })
-			expected := FactoryAlreadyProvidedError{TypeName: "int"}
-
-			assert.ErrorIs(t, got, expected)
-		})
-	})
-
 	t.Run("resolve", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("Cyclic dependency", func(t *testing.T) {
 			c := New()
 			c.Provide(func(s string) string { return s })
-			_, err := c.resolve(reflect.TypeOf(""), []reflect.Type{reflect.TypeOf("")})
-			expected := CyclicDependencyError{TypeName: "string"}
+			_, got := c.resolve(reflect.TypeOf(""), []reflect.Type{reflect.TypeOf("")})
+			expected := errs.CyclicDependencyError{TypeName: "string"}
 
-			assert.ErrorIs(t, err, expected)
+			assert.ErrorIs(t, got, expected)
 		})
 
 		t.Run("Unresolved dependency", func(t *testing.T) {
 			c := New()
-			_, err := c.resolve(reflect.TypeOf(0.0), nil)
-			expected := DependencyResolutionError{TypeName: "float64"}
+			_, got := c.resolve(reflect.TypeOf(0.0), nil)
+			expected := errs.DependencyResolutionError{TypeName: "float64"}
 
-			assert.ErrorIs(t, err, expected)
+			assert.ErrorIs(t, got, expected)
 		})
 
 		t.Run("Successful resolution", func(t *testing.T) {
@@ -83,10 +47,10 @@ func TestContainer(t *testing.T) {
 		t.Run("Recursive Call Error - Unresolved Dependency", func(t *testing.T) {
 			c := New()
 			c.Provide(func(f float64) int { return int(f) })
-			_, err := c.resolve(reflect.TypeOf(0), nil)
-			expected := DependencyResolutionError{TypeName: "float64"}
+			_, got := c.resolve(reflect.TypeOf(0), nil)
+			expected := errs.DependencyResolutionError{TypeName: "float64"}
 
-			assert.ErrorIs(t, err, expected)
+			assert.ErrorIs(t, got, expected)
 		})
 
 		t.Run("Recursive call error - cyclic dependency", func(t *testing.T) {
@@ -94,7 +58,7 @@ func TestContainer(t *testing.T) {
 			c.Provide(func(s string) int { return len(s) })
 			c.Provide(func(i int) string { return fmt.Sprint(i) })
 			_, err := c.resolve(reflect.TypeOf(0), nil)
-			expected := CyclicDependencyError{TypeName: "int"}
+			expected := errs.CyclicDependencyError{TypeName: "int"}
 
 			assert.ErrorIs(t, err, expected)
 		})
@@ -140,31 +104,108 @@ func TestContainer(t *testing.T) {
 			assert.Equal(t, a.C, b.C)
 		})
 
+		t.Run("Hooks Injection", func(t *testing.T) {
+			c := New()
+
+			err := c.Provide(func(h Hooks) *strings.Builder {
+				h.OnStart(func() error {
+					return nil
+				})
+
+				return &strings.Builder{}
+			})
+
+			assert.NilError(t, err)
+
+			val, err := c.resolve(reflect.TypeOf(&strings.Builder{}), nil)
+			assert.NilError(t, err)
+
+			_, ok := val.Interface().(*strings.Builder)
+			assert.Assert(t, ok)
+		})
+
+	})
+
+	t.Run("Provide", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("Not a function", func(t *testing.T) {
+			c := New()
+			got := c.Provide("string")
+			expected := errs.NotAFunctionError{}
+			assert.ErrorIs(t, got, expected)
+		})
+
+		t.Run("Invalid return count", func(t *testing.T) {
+			c := New()
+			got := c.Provide(func() (int, string, error) { return 0, "", nil })
+			expected := errs.InvalidFactoryReturnError{NumReturns: 3}
+
+			assert.ErrorIs(t, got, expected)
+		})
+
+		t.Run("Second return value not is a error", func(t *testing.T) {
+			c := New()
+			got := c.Provide(func() (int, string) { return 0, "" })
+			expected := errs.UnexpectedReturnTypeError{TypeName: "string"}
+
+			assert.ErrorIs(t, got, expected)
+		})
+
+		t.Run("Valid factory", func(t *testing.T) {
+			c := New()
+			err := c.Provide(func() int { return 0 })
+
+			assert.NilError(t, err)
+		})
+
+		t.Run("Duplicated factory", func(t *testing.T) {
+			c := New()
+			c.Provide(func() int { return 0 })
+			got := c.Provide(func() int { return 1 })
+			expected := errs.FactoryAlreadyProvidedError{TypeName: "int"}
+
+			assert.ErrorIs(t, got, expected)
+		})
+
+		t.Run("Hooks Injection", func(t *testing.T) {
+			c := New()
+
+			err := c.Provide(func(h Hooks) *strings.Builder {
+				return &strings.Builder{}
+			})
+			assert.NilError(t, err)
+
+			_, exists := c.providers[reflect.TypeOf(&strings.Builder{})]
+			assert.Assert(t, exists)
+		})
 	})
 
 	t.Run("Run", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("Not a function", func(t *testing.T) {
 			c := New()
-			err := c.Run("not a function")
-			expected := NotAFunctionError{}
+			got := c.Run("not a function")
+			expected := errs.NotAFunctionError{}
 
-			assert.ErrorIs(t, err, expected)
+			assert.ErrorIs(t, got, expected)
 		})
 
 		t.Run("Invalid return", func(t *testing.T) {
 			c := New()
-			err := c.Run(func() (int, string) { return 0, "" })
-			expected := InvalidFactoryReturnError{NumReturns: 2}
+			got := c.Run(func() (int, string) { return 0, "" })
+			expected := errs.InvalidFactoryReturnError{NumReturns: 2}
 
-			assert.ErrorIs(t, err, expected)
+			assert.ErrorIs(t, got, expected)
 		})
 
 		t.Run("Function returns a non-error value", func(t *testing.T) {
 			c := New()
-			err := c.Run(func() int { return 42 })
-			expected := UnexpectedReturnTypeError{TypeName: "int"}
+			got := c.Run(func() int { return 42 })
+			expected := errs.UnexpectedReturnTypeError{TypeName: "int"}
 
-			assert.ErrorIs(t, err, expected)
+			assert.ErrorIs(t, got, expected)
 		})
 
 		t.Run("Successful execution", func(t *testing.T) {
@@ -193,11 +234,64 @@ func TestContainer(t *testing.T) {
 
 		t.Run("Dependency resolution error", func(t *testing.T) {
 			c := New()
-			err := c.Run(func(f float64) error { return nil })
-			expected := DependencyResolutionError{TypeName: "float64"}
+			got := c.Run(func(f float64) error { return nil })
+			expected := errs.DependencyResolutionError{TypeName: "float64"}
 
-			assert.ErrorIs(t, err, expected)
+			assert.ErrorIs(t, got, expected)
 		})
 
+		t.Run("Successful Execution with Hooks", func(t *testing.T) {
+			c := New()
+
+			started := false
+			stopped := false
+
+			c.Provide(func(h Hooks) int {
+				h.OnStart(func() error {
+					started = true
+					return nil
+				})
+				h.OnStop(func() error {
+					stopped = true
+					return nil
+				})
+				return 42
+			})
+
+			err := c.Run(func(number int) {})
+
+			assert.NilError(t, err)
+			assert.Assert(t, started)
+			assert.Assert(t, stopped)
+		})
+
+		t.Run("Error in OnStart Hook", func(t *testing.T) {
+			c := New()
+
+			c.Provide(func(h Hooks) int {
+				h.OnStart(func() error {
+					return errors.New("start error")
+				})
+				return 42
+			})
+
+			err := c.Run(func(number int) {})
+			assert.ErrorContains(t, err, "start error")
+		})
+
+		t.Run("Error in OnStop Hook", func(t *testing.T) {
+			c := New()
+
+			c.Provide(func(h Hooks) int {
+				h.OnStop(func() error {
+					return errors.New("stop error")
+				})
+
+				return 42
+			})
+
+			err := c.Run(func(number int) {})
+			assert.ErrorContains(t, err, "stop error")
+		})
 	})
 }

--- a/facades.go
+++ b/facades.go
@@ -1,0 +1,17 @@
+package zeus
+
+import (
+	"github.com/otoru/zeus/hooks"
+)
+
+// Hooks is a facade for hooks.Hooks
+type Hooks hooks.Hooks
+
+// ErrorSet is a facade for errs.ErrorSet
+type ErrorSet interface {
+	IsEmpty() bool
+	Result() error
+	Error() string
+	Errors() []error
+	Add(err error)
+}

--- a/hooks/doc.go
+++ b/hooks/doc.go
@@ -1,0 +1,19 @@
+// Hooks defines an interface for a lifecycle of container.
+// Example of using the Zeus container with Hooks and ErrorSet:
+//
+//	c := zeus.New()
+//
+//	c.Provide(func(h Hooks) *sql.DB {
+//	   db := &sql.DB{} // pseudo-implementation
+//
+//	   h.OnStart(func() error {
+//	      return errors.New("Failed to authenticate")
+//	   })
+//
+//	   h.OnStop(func() error {
+//	      return errors.New("Failed to close the database")
+//	   })
+//
+//	   return db
+//	})
+package hooks

--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -1,0 +1,78 @@
+package hooks
+
+import (
+	"sync"
+
+	"github.com/otoru/zeus/errs"
+)
+
+// Hooks defines an interface for lifecycle events.
+// It provides methods to register functions that should be executed
+// at the start and stop of the application.
+type Hooks interface {
+	OnStart(func() error)
+	OnStop(func() error)
+	Start() error
+	Stop() error
+}
+
+// HooksImpl is the default implementation of the Hooks interface.
+type HooksImpl struct {
+	onStart []func() error
+	onStop  []func() error
+}
+
+// OnStart adds a function to the list of functions to be executed at the start.
+// Example:
+//
+//	hooks.OnStart(func() error {
+//	   fmt.Println("Starting...")
+//	   return nil
+//	})
+func (h *HooksImpl) OnStart(fn func() error) {
+	h.onStart = append(h.onStart, fn)
+}
+
+// OnStop adds a function to the list of functions to be executed at the stop.
+// Example:
+//
+//	hooks.OnStop(func() error {
+//	   fmt.Println("Stopping...")
+//	   return nil
+//	})
+func (h *HooksImpl) OnStop(fn func() error) {
+	h.onStop = append(h.onStop, fn)
+}
+
+// Start executes all the registered OnStart hooks.
+// It returns the first error encountered or nil if all hooks execute successfully.
+// This method is internally used by the Container's Run function.
+func (h *HooksImpl) Start() error {
+	for _, hook := range h.onStart {
+		if err := hook(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Stop executes all the registered OnStop hooks.
+// It returns the first error encountered or nil if all hooks execute successfully.
+// This method is internally used by the Container's Run function.
+func (h *HooksImpl) Stop() error {
+	var wg sync.WaitGroup
+	errorSet := &errs.ErrorSet{}
+
+	for _, hook := range h.onStop {
+		wg.Add(1)
+		go func(hook func() error) {
+			defer wg.Done()
+			if err := hook(); err != nil {
+				errorSet.Add(err)
+			}
+		}(hook)
+	}
+
+	wg.Wait()
+	return errorSet.Result()
+}


### PR DESCRIPTION
This PR introduces a major feature to Zeus

## Lifecycle Hooks
Users can now register hooks that run at the start and end of their application. This is especially useful for setups and teardowns, such as establishing a database connection or gracefully shutting down services.

## Changes
- Introduced ErrorSet: A structure to aggregate multiple errors.
- Updated Run method: Modified to return aggregated errors using ErrorSet when multiple errors occur and to execute lifecycle hooks.
- Added Lifecycle Hooks: Users can now register OnStart and OnStop hooks.
- Added Tests: Comprehensive tests to validate the behavior of ErrorSet, lifecycle hooks, and their integration with the Run method.

## How to Test
- Check out this branch.
- Run go test to execute the new test cases for error handling and hooks.

## Notes
With these enhancements, Zeus becomes more robust, allowing users to have better error insights and more control over the lifecycle of their applications.